### PR TITLE
Add attr_reader to expose the redis connection

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -4,6 +4,8 @@ require 'redis-store'
 module ActiveSupport
   module Cache
     class RedisStore < Store
+      attr_reader :data
+
       # Instantiate the store.
       #
       # Example:


### PR DESCRIPTION
In our application, we are using Redis for some other things
in addition to ActiveSupport::Cache::RedisStore and want
to reuse the underlying Redis connection, rather than creating
a new connection.  This attr_reader lets us do so.

Sponsored-by: CentroNet Marketing