### PR TITLE
Handling connection errors as cache misses

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -52,7 +52,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           begin
             !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
-          rescue Errno::ECONNREFUSED => e
+          rescue Errno::ECONNREFUSED, Redis::CannotConnectError
             false
           end
         end
@@ -161,7 +161,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           @data.send method, key, entry, options
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 
@@ -170,7 +170,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           nil
         end
 
@@ -181,7 +181,7 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           @data.del key
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 


### PR DESCRIPTION
Since [version 3.0](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md) the redis library raises Redis::CannotConnectError instead of Errno::ECONNREFUSED.

This pull request makes redis-activesupport ignore errors for both.
