### PR TITLE
Add a test for namespace parsing

### DIFF
--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 describe ActiveSupport::Cache::RedisStore do
   def setup
@@ -12,6 +13,16 @@ describe ActiveSupport::Cache::RedisStore do
       store.delete "counter"
       store.delete "rub-a-dub"
     end
+  end
+
+  it "namespaces all operations" do
+    address = "redis://127.0.0.1:6379/1/cache-namespace"
+    store   = ActiveSupport::Cache::RedisStore.new(address)
+    redis   = Redis.new(url: address)
+
+    store.write("white-rabbit", 0)
+
+    redis.exists('cache-namespace:white-rabbit').must_equal(true)
   end
 
   it "reads the data" do


### PR DESCRIPTION
While namespacing is documented in the cache class there was no example of its usage within the spec. This adds an explicit test to verify that namespacing is applied when provided in the redis url.

From my experience setting this up via `config.cache_store` it seemed like the namespace was not being applied. This led me to look into the specs, where I saw no mention of a namespace.
