### PR TITLE
Implement fetch_multi for parity with Rails 4.1

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -76,6 +76,26 @@ module ActiveSupport
         result
       end
 
+      def fetch_multi(*names)
+        results = read_multi(*names)
+        options = names.extract_options!
+        fetched = {}
+
+        @data.multi do
+          fetched = names.inject({}) do |memo, (name, _)|
+            memo[name] = results.fetch(name) do
+              value = yield name
+              write(name, value, options)
+              value
+            end
+
+            memo
+          end
+        end
+
+        fetched
+      end
+
       # Increment a key in the store.
       #
       # If the key doesn't exist it will be initialized on 0.

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'ostruct'
 
 describe ActiveSupport::Cache::RedisStore do
   def setup
@@ -194,6 +195,19 @@ describe ActiveSupport::Cache::RedisStore do
     result = @store.read_multi "rabbit", "irish whisky"
     result.wont_include('irish whisky')
     result.must_include('rabbit')
+  end
+
+  describe "fetch_multi" do
+    it "reads existing keys and fills in anything missing" do
+      @store.write "bourbon", "makers"
+
+      result = @store.fetch_multi("bourbon", "rye") do |key|
+        "#{key}-was-missing"
+      end
+
+      result.must_equal({ "bourbon" => "makers", "rye" => "rye-was-missing" })
+      @store.read("rye").must_equal("rye-was-missing")
+    end
   end
 
   describe "notifications" do


### PR DESCRIPTION
Attempts to be efficient by reading in a single block and writing all missing values within a multi block. I managed to get a _very_ similar implementation in [dalli](https://github.com/mperham/dalli). However, we are using Redis as the cache for a new app and I'd love to have similar functionality.
