### PR TITLE
Dependency on activesupport 4 was incorrect

### DIFF
--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'activesupport', '~> 4'
+  s.add_runtime_dependency 'activesupport', '~> 3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
* redis-activesupport.gemspec: lowered dependency to version 3 and higher

The existing code is still compatible with rails 3, which is helpful given how hard it is to get a working redis-store for rails 3.1 with most recent rack for that branch if you try to go the full redis-rails way.