### PR TITLE
Handling connection errors as cache misses in 3.2.x

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -46,7 +46,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           begin
             !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
-          rescue Errno::ECONNREFUSED
+          rescue Errno::ECONNREFUSED, Redis::CannotConnectError
             false
           end
         end
@@ -144,7 +144,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           @data.send method, key, entry, options
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 
@@ -153,7 +153,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           nil
         end
 
@@ -164,7 +164,7 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           @data.del key
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -46,7 +46,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           begin
             !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
-          rescue Errno::ECONNREFUSED, Redis::CannotConnectError
+          rescue Errno::ECONNREFUSED, Redis::CannotConnectError, Errno::EINVAL
             false
           end
         end
@@ -144,7 +144,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           @data.send method, key, entry, options
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError, Errno::EINVAL
           false
         end
 
@@ -153,7 +153,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError, Errno::EINVAL
           nil
         end
 
@@ -164,7 +164,7 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           @data.del key
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError, Errno::EINVAL
           false
         end
 

--- a/lib/redis/activesupport/version.rb
+++ b/lib/redis/activesupport/version.rb
@@ -1,5 +1,5 @@
 class Redis
   module ActiveSupport
-    VERSION = '3.2.5'
+    VERSION = '3.2.6'
   end
 end


### PR DESCRIPTION
I've backported 2cd4729 to 3.2.x.