### PR TITLE
Rescue Redis::CannotConnectError on read/write entry on 3.2.x branch

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -143,7 +143,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           @data.send method, key, entry, options
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 
@@ -152,7 +152,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           nil
         end
 


### PR DESCRIPTION
Redis client throws Redis::CannotConnectError when it fails to connect.

If the cache is not reachable, we should rescue that error and fallback to no-cache behavior.

This already exists on the master branch, this is to add it to 3.2.x branch.
