### PR TITLE
Rescue Redis::CannotConnectError on read/write entry on 3.2.x branch

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -46,7 +46,7 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           begin
             !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
-          rescue Errno::ECONNREFUSED
+          rescue Errno::ECONNREFUSED, Redis::CannotConnectError
             false
           end
         end
@@ -129,6 +129,8 @@ module ActiveSupport
         instrument(:clear, nil, nil) do
           @data.flushdb
         end
+      rescue Errno::ECONNREFUSED, Redis::CannotConnectError
+        nil
       end
 
       def stats
@@ -144,7 +146,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           @data.send method, key, entry, options
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 
@@ -153,7 +155,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           nil
         end
 
@@ -164,7 +166,7 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           @data.del key
-        rescue Errno::ECONNREFUSED => e
+        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 


### PR DESCRIPTION
Redis client throws Redis::CannotConnectError when it fails to connect.

If the cache is not reachable, we should rescue that error and fallback to no-cache behavior.

This already exists on the master branch, this is to add it to 3.2.x branch.