### PR TITLE
Travis: add recent versions of MRI, fix Rubinius/JRuby declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ script: 'bundle exec rake'
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1
   - ruby-head
-  - rbx-19mode
-  - jruby-19mode
+  - rbx-2
+  - jruby
   - jruby-head
 
 matrix:


### PR DESCRIPTION
This PR is an update of the Travis build configuration to include new versions of MRI and fix outdated declarations of JRuby/Rubinius.
Please note that it won't make the Travis builds pass again, as the real problem seems to be coming from errors in Redis configuration files in the "redis-store-testing".
I've made [another pull request](https://github.com/redis-store/testing/pull/3) intended to fix those, and it seems that a new release of this gem would be needed before having Travis builds green again.
I hope this will be useful !
