### PR TITLE
add support for connection pooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ rvm:
   - rbx-19mode
   - jruby-19mode
   - jruby-head
-
+services:
+  - redis-server
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -42,8 +42,8 @@ module ActiveSupport
                   @options[:pool]
                 elsif [:pool_size, :pool_timeout].any? { |key| @options.has_key?(key) }
                   pool_options           = {}
-                  pool_options[:size]    = options[:pool_size]
-                  pool_options[:timeout] = options[:pool_timeout]
+                  pool_options[:size]    = options[:pool_size] if options[:pool_size]
+                  pool_options[:timeout] = options[:pool_timeout] if options[:pool_timeout]
                   @data                  = ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(addresses) }
                 else
                   ::Redis::Store::Factory.create(addresses)

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -4,6 +4,8 @@ require 'redis-store'
 module ActiveSupport
   module Cache
     class RedisStore < Store
+      attr_reader :data
+
       # Instantiate the store.
       #
       # Example:
@@ -24,10 +26,30 @@ module ActiveSupport
       #
       #   RedisStore.new "localhost:6379/0", "localhost:6380/0"
       #     # => instantiate a cluster
+      #
+      #   RedisStore.new "localhost:6379/0", "localhost:6380/0", pool_size: 5, pool_timeout: 10
+      #     # => use a ConnectionPool
+      #
+      #   RedisStore.new "localhost:6379/0", "localhost:6380/0",
+      #     pool: ::ConnectionPool.new(size: 1, timeout: 1) { ::Redis::Store::Factory.create("localhost:6379/0") })
+      #     # => supply an existing connection pool (e.g. for use with redis-sentinel or redis-failover)
       def initialize(*addresses)
-        options = addresses.extract_options!
-        @data = ::Redis::Store::Factory.create(addresses)
-        super(options)
+        @options = addresses.extract_options!
+
+        @data = if @options[:pool]
+                  raise "pool must be an instance of ConnectionPool" unless @options[:pool].is_a?(ConnectionPool)
+
+                  @options[:pool]
+                elsif [:pool_size, :pool_timeout].any? { |key| @options.has_key?(key) }
+                  pool_options           = {}
+                  pool_options[:size]    = options[:pool_size]
+                  pool_options[:timeout] = options[:pool_timeout]
+                  @data                  = ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(addresses) }
+                else
+                  ::Redis::Store::Factory.create(addresses)
+                end
+
+        super(@options)
       end
 
       def write(name, value, options = nil)
@@ -52,7 +74,9 @@ module ActiveSupport
         instrument(:delete_matched, matcher.inspect) do
           matcher = key_matcher(matcher, options)
           begin
-            !(keys = @data.keys(matcher)).empty? && @data.del(*keys)
+            with do |store|
+              !(keys = store.keys(matcher)).empty? && store.del(*keys)
+            end
           rescue Errno::ECONNREFUSED, Redis::CannotConnectError
             false
           end
@@ -66,7 +90,7 @@ module ActiveSupport
       #   cache.read_multi "rabbit", "white-rabbit"
       #   cache.read_multi "rabbit", "white-rabbit", :raw => true
       def read_multi(*names)
-        values = @data.mget(*names)
+        values = with { |c| c.mget(*names) }
         values.map! { |v| v.is_a?(ActiveSupport::Cache::Entry) ? v.value : v }
 
         # Remove the options hash before mapping keys to values
@@ -82,15 +106,17 @@ module ActiveSupport
         options = names.extract_options!
         fetched = {}
 
-        @data.multi do
-          fetched = names.inject({}) do |memo, (name, _)|
-            memo[name] = results.fetch(name) do
-              value = yield name
-              write(name, value, options)
-              value
-            end
+        with do |c|
+          c.multi do
+            fetched = names.inject({}) do |memo, (name, _)|
+              memo[name] = results.fetch(name) do
+                value = yield name
+                write(name, value, options)
+                value
+              end
 
-            memo
+              memo
+            end
           end
         end
 
@@ -120,7 +146,7 @@ module ActiveSupport
       #   cache.read "rabbit", :raw => true       # => "1"
       def increment(key, amount = 1)
         instrument(:increment, key, :amount => amount) do
-          @data.incrby key, amount
+          with{|c| c.incrby key, amount}
         end
       end
 
@@ -147,18 +173,19 @@ module ActiveSupport
       #   cache.read "rabbit", :raw => true       # => "-1"
       def decrement(key, amount = 1)
         instrument(:decrement, key, :amount => amount) do
-          @data.decrby key, amount
+          with{|c| c.decrby key, amount}
+
         end
       end
 
       def expire(key, ttl)
-        @data.expire key, ttl
+        with { |c| c.expire key, ttl }
       end
 
       # Clear all the data from the store.
       def clear
         instrument(:clear, nil, nil) do
-          @data.flushdb
+          with(&:flushdb)
         end
       end
 
@@ -170,24 +197,31 @@ module ActiveSupport
       end
 
       def stats
-        @data.info
+        with(&:info)
       end
 
-      # Force client reconnection, useful Unicorn deployed apps.
+      def with(&block)
+        if @data.is_a?(::Redis::Store) || @data.is_a?(::Redis::DistributedStore)
+          block.call(@data)
+        else
+          @data.with(&block)
+        end
+      end
+
       def reconnect
-        @data.reconnect
+        @data.reconnect if @data.respond_to?(:reconnect)
       end
 
       protected
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
-          @data.send method, key, entry, options
+          with { |client| client.send method, key, entry, options }
         rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end
 
         def read_entry(key, options)
-          entry = @data.get key, options
+          entry = with { |c| c.get key, options }
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
@@ -201,7 +235,7 @@ module ActiveSupport
         # It's really needed and use
         #
         def delete_entry(key, options)
-          @data.del key
+          entry = with { |c| c.del key }
         rescue Errno::ECONNREFUSED, Redis::CannotConnectError
           false
         end

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',  '~> 1.3'
   s.add_development_dependency 'mocha',    '~> 0.14.0'
   s.add_development_dependency 'minitest', '~> 4.2'
+  s.add_development_dependency 'connection_pool',     '~> 1.2.0'
   s.add_development_dependency 'redis-store-testing'
 end
 

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -5,7 +5,7 @@ require 'connection_pool'
 describe ActiveSupport::Cache::RedisStore do
   def setup
     @store  = ActiveSupport::Cache::RedisStore.new
-    @dstore = ActiveSupport::Cache::RedisStore.new "redis://127.0.0.1:6380/1", "redis://127.0.0.1:6381/1"
+    @dstore = ActiveSupport::Cache::RedisStore.new "redis://127.0.0.1:6379/5", "redis://127.0.0.1:6379/6"
     @pool_store  = ActiveSupport::Cache::RedisStore.new("redis://127.0.0.1:6379/2", pool_size: 5, pool_timeout: 10)
     @external_pool_store = ActiveSupport::Cache::RedisStore.new(pool: ::ConnectionPool.new(size: 1, timeout: 1) { ::Redis::Store::Factory.create("redis://127.0.0.1:6379/3") })
 


### PR DESCRIPTION
You can either supply size and timeout parameters, or a pool of your own creation.

Fixes #22.