### PR TITLE
don't require active support 4

### DIFF
--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'activesupport', '~> 4'
+  s.add_runtime_dependency 'activesupport', '~> 3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'


### PR DESCRIPTION
As far as I can tell, there is no reason for this to have a hard dependency on 4.0.  This makes it hard for people not on rails 4 to use the latest version of this gem.