### PR TITLE
Specifying default cache options no longer accidentally creates a DistributedStore

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -25,8 +25,9 @@ module ActiveSupport
       #   RedisStore.new "localhost:6379/0", "localhost:6380/0"
       #     # => instantiate a cluster
       def initialize(*addresses)
+        options = addresses.extract_options!
         @data = ::Redis::Store::Factory.create(addresses)
-        super(addresses.extract_options!)
+        super(options)
       end
 
       def write(name, value, options = nil)

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -16,13 +16,47 @@ describe ActiveSupport::Cache::RedisStore do
   end
 
   it "namespaces all operations" do
-    address = "redis://127.0.0.1:6379/1/cache-namespace"
+    address = "redis://127.0.0.1:6380/1/cache-namespace"
     store   = ActiveSupport::Cache::RedisStore.new(address)
     redis   = Redis.new(url: address)
 
     store.write("white-rabbit", 0)
 
     redis.exists('cache-namespace:white-rabbit').must_equal(true)
+  end
+
+  it "creates a normal store when given no addresses" do
+    underlying_store = instantiate_store
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a normal store when given options only" do
+    underlying_store = instantiate_store(:expires_in => 1.second)
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a normal store when given a single address" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1")
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a normal store when given a single address and options" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1",
+                                         { :expires_in => 1.second})
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
+  it "creates a distributed store when given multiple addresses" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1", 
+                                         "redis://127.0.0.1:6381/1")
+    underlying_store.must_be_instance_of(::Redis::DistributedStore)
+  end
+
+  it "creates a distributed store when given multiple address and options" do
+    underlying_store = instantiate_store("redis://127.0.0.1:6380/1",
+                                         "redis://127.0.0.1:6381/1",
+                                         :expires_in => 1.second)
+    underlying_store.must_be_instance_of(::Redis::DistributedStore)
   end
 
   it "reads the data" do
@@ -311,8 +345,8 @@ describe ActiveSupport::Cache::RedisStore do
   end
 
   private
-    def instantiate_store(addresses = nil)
-      ActiveSupport::Cache::RedisStore.new(addresses).instance_variable_get(:@data)
+    def instantiate_store(*addresses)
+      ActiveSupport::Cache::RedisStore.new(*addresses).instance_variable_get(:@data)
     end
 
     def with_store_management


### PR DESCRIPTION
This pull request includes the failing tests created in redis-store/redis-store#166 (prior to break-up of repository into multiple gems), along with a fix which makes the tests pass.

This patch causes the options to be extracted from the addresses arguments passed in to Store#initialize prior to calling the Redis::Factory::create method.

This PR supercedes the older redis-store/redis-store#169 PR which was made against the older `redis-store` repo structure.