### PR TITLE
Fixed arguments passing in RedisStore#initialize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 script: 'bundle exec rake'
 rvm:
-  - 1.9.3
-  - 2.0.0
+  - 2.2.0
   - ruby-head
   - rbx-19mode
   - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ rvm:
   - rbx-19mode
   - jruby-19mode
   - jruby-head
-services:
-  redis-server:
-    port: 6380
-  redis-server:
-    password: "password"
-    port: 6379
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ script: 'bundle exec rake'
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.2.0
   - ruby-head
   - rbx-19mode
   - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - jruby-19mode
   - jruby-head
 services:
-  - redis-server
+  - redis-server --port 6380 --requirepass 'password'
 matrix:
   allow_failures:
     - rvm: jruby-head

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are on **Snow Leopard** you have to run `env ARCHFLAGS="-arch x86_64" bun
 
 ## Status
 
-[![Gem Version](https://badge.fury.io/rb/redis-activesupport.png)](http://badge.fury.io/rb/redis-activesupport) [![Build Status](https://secure.travis-ci.org/redis-store/redis-activesupport.png?branch=master)](http://travis-ci.org/jodosha/redis-activesupport?branch=master) [![Code Climate](https://codeclimate.com/github/jodosha/redis-store.png)](https://codeclimate.com/github/redis-store/redis-activesupport)
+[![Gem Version](https://badge.fury.io/rb/redis-activesupport.png)](http://badge.fury.io/rb/redis-activesupport) [![Build Status](https://secure.travis-ci.org/bukk530/redis-activesupport.png?branch=master)](http://travis-ci.org/jodosha/redis-activesupport?branch=master) [![Code Climate](https://codeclimate.com/github/jodosha/redis-store.png)](https://codeclimate.com/github/redis-store/redis-activesupport)
 
 ## Copyright
 

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -34,7 +34,7 @@ module ActiveSupport
       #     pool: ::ConnectionPool.new(size: 1, timeout: 1) { ::Redis::Store::Factory.create("localhost:6379/0") })
       #     # => supply an existing connection pool (e.g. for use with redis-sentinel or redis-failover)
       def initialize(*addresses)
-        @options = addresses.extract_options!
+        @options = addresses.dup.extract_options!
 
         @data = if @options[:pool]
                   raise "pool must be an instance of ConnectionPool" unless @options[:pool].is_a?(ConnectionPool)

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -30,7 +30,7 @@ describe ActiveSupport::Cache::RedisStore do
     options = { :port => 6379, :password => 'password' }
     store = ActiveSupport::Cache::RedisStore.new(address, options)
 
-    store.write "rabbit", @rabbit,
+    store.write "rabbit", @rabbit
     store.read("rabbit").must_equal(@rabbit)
   end
 

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,0 +1,5 @@
+redis-server:
+  port: 6380
+redis-server:
+  password: "password"
+  port: 6379


### PR DESCRIPTION
When a RedisStore class was initialized, arguments in the 'addresses' variable were extracted using the 'exctract_options!' method, which empties the original variable.
'addresses' is now duplicated before calling 'exctract_options!'