### PR TITLE
addresses reseted in RedisStore constructor

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -45,9 +45,9 @@ module ActiveSupport
                   pool_options[:size]    = options[:pool_size] if options[:pool_size]
                   pool_options[:timeout] = options[:pool_timeout] if options[:pool_timeout]
                   @pooled = true
-                  ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(addresses) }
+                  ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(@options) }
                 else
-                  ::Redis::Store::Factory.create(addresses)
+                  ::Redis::Store::Factory.create(@options)
                 end
 
         super(@options)


### PR DESCRIPTION
I found a bug when Redis server need a password: "NOAUTH Authentication required."
addresses.extract_options! reset addresses with value [] so, password didn't send in Redis Store Factory