### PR TITLE
Use SCAN for delete_matched if client and server supports it

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -63,10 +63,13 @@ module ActiveSupport
 
       # Delete objects for matched keys.
       #
+      # Uses SCAN to iterate and collect matched keys only when both client and
+      # server supports it (Redis server >= 2.8.0, client >= 3.0.6)
+      #
       # Performance note: this operation can be dangerous for large production
-      # databases, as it uses the Redis "KEYS" command, which is O(N) over the
-      # total number of keys in the database. Users of large Redis caches should
-      # avoid this method.
+      # databases on Redis < 2.8.0, as it uses the Redis "KEYS" command, which
+      # is O(N) over the total number of keys in the database. Users of large
+      # Redis caches should avoid this method.
       #
       # Example:
       #   cache.delete_matched "rab*"
@@ -76,7 +79,17 @@ module ActiveSupport
           matcher = key_matcher(matcher, options)
           begin
             with do |store|
-              !(keys = store.keys(matcher)).empty? && store.del(*keys)
+              supports_scan_each = store.respond_to?(:supports_redis_version?) &&
+                store.supports_redis_version?("2.8.0") &&
+                store.respond_to?(:scan_each)
+
+              if supports_scan_each
+                keys = store.scan_each(match: matcher).to_a
+              else
+                keys = store.keys(matcher)
+              end
+
+              !keys.empty? && store.del(*keys)
             end
           rescue Errno::ECONNREFUSED, Redis::CannotConnectError
             false

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -193,8 +193,12 @@ describe ActiveSupport::Cache::RedisStore do
 
   it "deletes matched data" do
     with_store_management do |store|
+      store.write "rabbit2", @white_rabbit
+      store.write "rub-a-dub", "Flora de Cana"
       store.delete_matched "rabb*"
       store.read("rabbit").must_be_nil
+      store.read("rabbit2").must_be_nil
+      store.exist?("rub-a-dub").must_equal(true)
     end
   end
 


### PR DESCRIPTION
This is similar to PR #18 , except that it only attempts to use SCAN if the server (any version >= 2.8.0 and not just 2.8.*) and if the client (version > 3.0.6) has support for scan_each.

Not sure if code to retrieve server version should be here or in redis-store gem instead, I'm open to suggestions on this.