### PR TITLE
Test against both AS 3.x and AS 4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 *.gem
 tmp/
+gemfiles/*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ gemfile:
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.5
   - ruby-head
   - rbx-19mode
   - jruby-19mode

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 script: 'bundle exec rake'
+gemfile:
+  - gemfiles/Gemfile.activesupport-3.x
+  - gemfiles/Gemfile.activesupport-4.x
 rvm:
   - 1.9.3
   - 2.0.0

--- a/gemfiles/Gemfile.activesupport-3.x
+++ b/gemfiles/Gemfile.activesupport-3.x
@@ -1,0 +1,13 @@
+source "http://rubygems.org"
+
+gem 'redis-store', '~> 1.1.0'
+gem 'activesupport', '~> 3'
+
+group :development do
+  gem 'rake', '~> 10'
+  gem 'bundler', '~> 1.3'
+  gem 'mocha', '~> 0.14.0'
+  gem 'minitest', '~> 4.2'
+  gem 'connection_pool', '~> 1.2.0'
+  gem 'redis-store-testing'
+end

--- a/gemfiles/Gemfile.activesupport-4.x
+++ b/gemfiles/Gemfile.activesupport-4.x
@@ -1,0 +1,13 @@
+source "http://rubygems.org"
+
+gem 'redis-store', '~> 1.1.0'
+gem 'activesupport', '~> 4'
+
+group :development do
+  gem 'rake', '~> 10'
+  gem 'bundler', '~> 1.3'
+  gem 'mocha', '~> 0.14.0'
+  gem 'minitest', '~> 4.2'
+  gem 'connection_pool', '~> 1.2.0'
+  gem 'redis-store-testing'
+end

--- a/lib/redis/activesupport/version.rb
+++ b/lib/redis/activesupport/version.rb
@@ -1,5 +1,0 @@
-class Redis
-  module ActiveSupport
-    VERSION = '4.1.1'
-  end
-end

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'activesupport', '~> 4'
+  s.add_runtime_dependency 'activesupport', '~> 3'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -1,10 +1,9 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-require 'redis/activesupport/version'
 
 Gem::Specification.new do |s|
   s.name        = 'redis-activesupport'
-  s.version     = Redis::ActiveSupport::VERSION
+  s.version     = '4.1.1'
   s.authors     = ['Luca Guidi']
   s.email       = ['me@lucaguidi.com']
   s.homepage    = 'http://redis-store.org/redis-activesupport'

--- a/test/redis/activesupport/version_test.rb
+++ b/test/redis/activesupport/version_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-describe Redis::ActiveSupport::VERSION do
-  it 'returns current version' do
-    Redis::ActiveSupport::VERSION.must_equal '4.1.1'
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,4 @@ require 'mocha/setup'
 require 'active_support'
 require 'active_support/cache/redis_store'
 
+puts "Testing against ActiveSupport v.#{ActiveSupport::VERSION::STRING}"


### PR DESCRIPTION
Supercedes https://github.com/redis-store/redis-activesupport/pull/7, downgrades the AS dependency to allow for Rails 3 compatibility, adds Travis matrix for tests against 3.x too.

Note that the VERSION constant test fails for me because the ActiveSupport::VERSION is a module, not a string.