### PR TITLE
Can not deploy and missing redis/activesupport/version

### DIFF
--- a/lib/redis-activesupport.rb
+++ b/lib/redis-activesupport.rb
@@ -1,4 +1,3 @@
 require 'redis-store'
 require 'active_support'
-require 'redis/activesupport/version'
 require 'active_support/cache/redis_store'


### PR DESCRIPTION
Seems coming from #36

```
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as mv@mesview.sandisk.com: rake exit status: 1
rake stdout: Nothing written
rake stderr: rake aborted!
LoadError: cannot load such file -- redis/activesupport/version
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `block in require'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:240:in `load_dependency'
/usr/local/rvm/gems/ruby-2.2.3/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
/usr/local/rvm/gems/ruby-2.2.3/gems/redis-activesupport-4.1.2/lib/redis-activesupport.rb:3:in `<top (required)>'
```