### PR TITLE
Do not swallow errors if there are issues communicating with Redis

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -74,12 +74,8 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:delete_matched, matcher.inspect) do
           matcher = key_matcher(matcher, options)
-          begin
-            with do |store|
-              !(keys = store.keys(matcher)).empty? && store.del(*keys)
-            end
-          rescue Errno::ECONNREFUSED, Redis::CannotConnectError
-            false
+          with do |store|
+            !(keys = store.keys(matcher)).empty? && store.del(*keys)
           end
         end
       end
@@ -220,8 +216,6 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           with { |client| client.send method, key, entry, options }
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
-          false
         end
 
         def read_entry(key, options)
@@ -229,8 +223,6 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
-          nil
         end
 
         ##
@@ -240,8 +232,6 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           entry = with { |c| c.del key }
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError
-          false
         end
 
 

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -111,6 +111,16 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "raises on read when redis is unavailable" do
+    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
+
+    with_store_management do |store|
+      assert_raises(Redis::CannotConnectError) do
+        store.read("rabbit")
+      end
+    end
+  end
+
   it "writes the data" do
     with_store_management do |store|
       store.write "rabbit", @white_rabbit
@@ -131,6 +141,16 @@ describe ActiveSupport::Cache::RedisStore do
       store.read("rabbit").must_equal(@white_rabbit)
       sleep 2
       store.read("rabbit").must_be_nil
+    end
+  end
+
+  it "raises on writes when redis is unavailable" do
+    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
+
+    with_store_management do |store|
+      assert_raises(Redis::CannotConnectError) do
+        store.write "rabbit", @white_rabbit, :expires_in => 1.second
+      end
     end
   end
 
@@ -183,6 +203,16 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "raises on delete when redis is unavailable" do
+    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
+
+    with_store_management do |store|
+      assert_raises(Redis::CannotConnectError) do
+        store.delete "rabbit"
+      end
+    end
+  end
+
   it "deletes namespaced data" do
     with_store_management do |store|
       store.write "rabbit", @white_rabbit, namespace:'namespaced'
@@ -195,6 +225,16 @@ describe ActiveSupport::Cache::RedisStore do
     with_store_management do |store|
       store.delete_matched "rabb*"
       store.read("rabbit").must_be_nil
+    end
+  end
+
+  it "raises on delete_matched when redis is unavailable" do
+    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
+
+    with_store_management do |store|
+      assert_raises(Redis::CannotConnectError) do
+        store.delete_matched "rabb*"
+      end
     end
   end
 

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -111,16 +111,6 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
-  it "raises on read when redis is unavailable" do
-    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
-
-    with_store_management do |store|
-      assert_raises(Redis::CannotConnectError) do
-        store.read("rabbit")
-      end
-    end
-  end
-
   it "writes the data" do
     with_store_management do |store|
       store.write "rabbit", @white_rabbit
@@ -141,16 +131,6 @@ describe ActiveSupport::Cache::RedisStore do
       store.read("rabbit").must_equal(@white_rabbit)
       sleep 2
       store.read("rabbit").must_be_nil
-    end
-  end
-
-  it "raises on writes when redis is unavailable" do
-    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
-
-    with_store_management do |store|
-      assert_raises(Redis::CannotConnectError) do
-        store.write "rabbit", @white_rabbit, :expires_in => 1.second
-      end
     end
   end
 
@@ -203,16 +183,6 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
-  it "raises on delete when redis is unavailable" do
-    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
-
-    with_store_management do |store|
-      assert_raises(Redis::CannotConnectError) do
-        store.delete "rabbit"
-      end
-    end
-  end
-
   it "deletes namespaced data" do
     with_store_management do |store|
       store.write "rabbit", @white_rabbit, namespace:'namespaced'
@@ -225,16 +195,6 @@ describe ActiveSupport::Cache::RedisStore do
     with_store_management do |store|
       store.delete_matched "rabb*"
       store.read("rabbit").must_be_nil
-    end
-  end
-
-  it "raises on delete_matched when redis is unavailable" do
-    ActiveSupport::Cache::RedisStore.any_instance.stubs(:with).raises(Redis::CannotConnectError)
-
-    with_store_management do |store|
-      assert_raises(Redis::CannotConnectError) do
-        store.delete_matched "rabb*"
-      end
     end
   end
 
@@ -477,6 +437,60 @@ describe ActiveSupport::Cache::RedisStore do
       clear = @events.first
       clear.name.must_equal('cache_clear.active_support')
       clear.payload.must_equal({ :key => nil })
+    end
+  end
+
+  describe "raise_errors => true" do
+    def setup
+      @raise_error_store = ActiveSupport::Cache::RedisStore.new("redis://127.0.0.1:6380/1", :raise_errors => true)
+      @raise_error_store.stubs(:with).raises(Redis::CannotConnectError)
+    end
+
+    it "raises on read when redis is unavailable" do
+      assert_raises(Redis::CannotConnectError) do
+        @raise_error_store.read("rabbit")
+      end
+    end
+
+    it "raises on writes when redis is unavailable" do
+      assert_raises(Redis::CannotConnectError) do
+        @raise_error_store.write "rabbit", @white_rabbit, :expires_in => 1.second
+      end
+    end
+
+    it "raises on delete when redis is unavailable" do
+      assert_raises(Redis::CannotConnectError) do
+        @raise_error_store.delete "rabbit"
+      end
+    end
+
+    it "raises on delete_matched when redis is unavailable" do
+      assert_raises(Redis::CannotConnectError) do
+        @raise_error_store.delete_matched "rabb*"
+      end
+    end
+  end
+
+  describe "raise_errors => false" do
+    def setup
+      @raise_error_store = ActiveSupport::Cache::RedisStore.new("redis://127.0.0.1:6380/1")
+      @raise_error_store.stubs(:with).raises(Redis::CannotConnectError)
+    end
+
+    it "is nil when redis is unavailable" do
+      @raise_error_store.read("rabbit").must_be_nil
+    end
+
+    it "returns false when redis is unavailable" do
+      @raise_error_store.write("rabbit", @white_rabbit, :expires_in => 1.second).must_equal(false)
+    end
+
+    it "returns false when redis is unavailable" do
+      @raise_error_store.delete("rabbit").must_equal(false)
+    end
+
+    it "raises on delete_matched when redis is unavailable" do
+      @raise_error_store.delete_matched("rabb*").must_equal(false)
     end
   end
 


### PR DESCRIPTION
If Redis is ever unreachable, users might want to handle this differently than falling back to what they would normally do if something doesn't exist in the cache.

Thoughts?