### PR TITLE
rescue Errno::EHOSTUNREACH

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -78,7 +78,7 @@ module ActiveSupport
             with do |store|
               !(keys = store.keys(matcher)).empty? && store.del(*keys)
             end
-          rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Redis::CannotConnectError => e
             raise if raise_errors?
             false
           end
@@ -221,7 +221,7 @@ module ActiveSupport
         def write_entry(key, entry, options)
           method = options && options[:unless_exist] ? :setnx : :set
           with { |client| client.send method, key, entry, options }
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Redis::CannotConnectError => e
           raise if raise_errors?
           false
         end
@@ -231,7 +231,7 @@ module ActiveSupport
           if entry
             entry.is_a?(ActiveSupport::Cache::Entry) ? entry : ActiveSupport::Cache::Entry.new(entry)
           end
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Redis::CannotConnectError => e
           raise if raise_errors?
           nil
         end
@@ -243,7 +243,7 @@ module ActiveSupport
         #
         def delete_entry(key, options)
           entry = with { |c| c.del key }
-        rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Redis::CannotConnectError => e
           raise if raise_errors?
           false
         end


### PR DESCRIPTION
In addition to rescuing `Errno::ECONNREFUSED` and `Redis::CannotConnectError` rescue `Errno::EHOSTUNREACH` for when redis is unreachable. 

closes #44 