### PR TITLE
make #read_multi & #fetch_multi AS compliant when namespaced

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -100,7 +100,7 @@ module ActiveSupport
         # Remove the options hash before mapping keys to values
         names.extract_options!
 
-        result = Hash[keys.zip(values)]
+        result = Hash[names.zip(values)]
         result.reject!{ |k,v| v.nil? }
         result
       end
@@ -113,8 +113,7 @@ module ActiveSupport
         with do |c|
           c.multi do
             fetched = names.inject({}) do |memo, (name, _)|
-              key = namespaced_key(name, options)
-              memo[key] = results.fetch(key) do
+              memo[name] = results.fetch(name) do
                 value = yield name
                 write(name, value, options)
                 value

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -309,8 +309,8 @@ describe ActiveSupport::Cache::RedisStore do
     @store.write "rub-a-dub", "Flora de Cana", namespace:'namespaced'
     @store.write "irish whisky", "Jameson", namespace:'namespaced'
     result = @store.read_multi "rub-a-dub", "irish whisky", namespace:'namespaced'
-    result['namespaced:rub-a-dub'].must_equal("Flora de Cana")
-    result['namespaced:irish whisky'].must_equal("Jameson")
+    result['rub-a-dub'].must_equal("Flora de Cana")
+    result['irish whisky'].must_equal("Jameson")
   end
 
   describe "fetch_multi" do
@@ -334,7 +334,7 @@ describe ActiveSupport::Cache::RedisStore do
         "#{key}-was-missing"
       end
 
-      result.must_equal({ "namespaced:bourbon" => "makers", "namespaced:rye" => "rye-was-missing" })
+      result.must_equal({ "bourbon" => "makers", "rye" => "rye-was-missing" })
       @store.read("namespaced:rye").must_equal("rye-was-missing")
     end
   end


### PR DESCRIPTION
ActiveSupport (tried with 4.2.5, but I think it was always so) returns toplevel keys without namespaces (though store reads/writes are namespaced)

```
> Rails.cache.write 'foo', 'bar', namespace: 'baz'
=> true

> Rails.cache.read_multi 'foo', namespace: 'baz'
=> {"foo"=>"bar"} # not {"baz.foo"=>"bar"}
```

also see #27 & #28 