### PR TITLE
Support Rails 5 (ActiveSupport 5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ script: 'bundle exec rake'
 gemfile:
   - gemfiles/Gemfile.activesupport-3.x
   - gemfiles/Gemfile.activesupport-4.x
+  - gemfiles/Gemfile.activesupport-5.x
 rvm:
   - 1.9.3
   - 2.0.0
@@ -18,3 +19,9 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.activesupport-5.x
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.activesupport-5.x
+    - rvm: 2.1.5
+      gemfile: gemfiles/Gemfile.activesupport-5.x

--- a/gemfiles/Gemfile.activesupport-5.x
+++ b/gemfiles/Gemfile.activesupport-5.x
@@ -1,0 +1,13 @@
+source "http://rubygems.org"
+
+gem 'redis-store', '~> 1.1.0'
+gem 'activesupport', '>= 5.0.0.beta1', '< 5.1'
+
+group :development do
+  gem 'rake', '~> 10'
+  gem 'bundler', '~> 1.3'
+  gem 'mocha', '~> 0.14.0'
+  gem 'minitest', '~> 5.1'
+  gem 'connection_pool', '~> 1.2.0'
+  gem 'redis-store-testing'
+end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -57,7 +57,7 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:write, name, options) do |payload|
           entry = options[:raw].present? ? value : Entry.new(value, options)
-          write_entry(namespaced_key(name, options), entry, options)
+          write_entry(normalize_key(name, options), entry, options)
         end
       end
 
@@ -93,7 +93,7 @@ module ActiveSupport
       #   cache.read_multi "rabbit", "white-rabbit", :raw => true
       def read_multi(*names)
         options = names.extract_options!
-        keys = names.map{|name| namespaced_key(name, options)}
+        keys = names.map{|name| normalize_key(name, options)}
         values = with { |c| c.mget(*keys) }
         values.map! { |v| v.is_a?(ActiveSupport::Cache::Entry) ? v.value : v }
 
@@ -113,7 +113,7 @@ module ActiveSupport
         with do |c|
           c.multi do
             fetched = names.inject({}) do |memo, (name, _)|
-              key = namespaced_key(name, options)
+              key = normalize_key(name, options)
               memo[key] = results.fetch(key) do
                 value = yield name
                 write(name, value, options)

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
-  s.add_runtime_dependency 'activesupport', '>= 3', '< 5'
+  s.add_runtime_dependency 'activesupport', '>= 3', '< 6'
 
   s.add_development_dependency 'rake',     '~> 10'
   s.add_development_dependency 'bundler',  '~> 1.3'
   s.add_development_dependency 'mocha',    '~> 0.14.0'
-  s.add_development_dependency 'minitest', '~> 4.2'
+  s.add_development_dependency 'minitest', '>= 4.2', '< 6'
   s.add_development_dependency 'connection_pool',     '~> 1.2.0'
   s.add_development_dependency 'redis-store-testing'
 end

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -508,12 +508,10 @@ describe ActiveSupport::Cache::RedisStore do
 
     def with_notifications
       @events = [ ]
-      ActiveSupport::Cache::RedisStore.instrument = true
       ActiveSupport::Notifications.subscribe(/^cache_(.*)\.active_support$/) do |*args|
         @events << ActiveSupport::Notifications::Event.new(*args)
       end
       yield
-      ActiveSupport::Cache::RedisStore.instrument = false
     end
 end
 


### PR DESCRIPTION
The current version of redis-activesupport works with Rails 5.0.0.beta1 and shows some deprecation warnings.

This commit is meant to upgrade the code of redis-activesupport to remove those deprecation warnings.

Given large matrix of tests run on redis-activesupport, I will open a PR to check what the backward compatibility looks like.

This PR is not meant to be accepted before Travis is all green :green_heart: 