### PR TITLE
verify if the variable is defined before read it to avoid warnings

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -206,7 +206,7 @@ module ActiveSupport
       end
 
       def with(&block)
-        if @pooled
+        if defined?(@pooled) && @pooled
           @data.with(&block)
         else
           block.call(@data)


### PR DESCRIPTION
avoid about 200k warnings when tests run
use `RUBYOPT=-w rake` to check it