### PR TITLE
Store#increment and #decrement must support the options argument

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -153,7 +153,7 @@ module ActiveSupport
       #
       #   cache.increment "rabbit"
       #   cache.read "rabbit", :raw => true       # => "1"
-      def increment(key, amount = 1)
+      def increment(key, amount = 1, options = {})
         instrument(:increment, key, :amount => amount) do
           with{|c| c.incrby key, amount}
         end
@@ -180,7 +180,7 @@ module ActiveSupport
       #
       #   cache.decrement "rabbit"
       #   cache.read "rabbit", :raw => true       # => "-1"
-      def decrement(key, amount = 1)
+      def decrement(key, amount = 1, options = {})
         instrument(:decrement, key, :amount => amount) do
           with{|c| c.decrby key, amount}
 

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -228,6 +228,14 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "increments a key with options argument" do
+    with_store_management do |store|
+      assert store.write("raw-counter", 1, :raw => true)
+      store.increment("raw-counter", 2, nil)
+      store.read("raw-counter", :raw => true).to_i.must_equal(3)
+    end
+  end
+  
   it "decrements a raw key" do
     with_store_management do |store|
       assert store.write("raw-counter", 3, :raw => true)
@@ -247,6 +255,14 @@ describe ActiveSupport::Cache::RedisStore do
     with_store_management do |store|
       3.times { store.increment "counter" }
       store.decrement "counter", 2
+      store.read("counter", :raw => true).to_i.must_equal(1)
+    end
+  end
+
+  it "decrements a key with an options argument" do
+    with_store_management do |store|
+      3.times { store.increment "counter" }
+      store.decrement "counter", 2, nil
       store.read("counter", :raw => true).to_i.must_equal(1)
     end
   end


### PR DESCRIPTION
According to the Rails API guide for a Store, a third argument is accepted for `Store#increment` and `Store#decrement`, and the store can elect to use that argument or ignore it. If the store is wrapped into another object for delegation, the method signature of the store should match the expected signature of the ActiveSupport method.

http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-increment
http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-decrement

The fact that this was not the case warranted patching our cache store wrapper to ensure the divergent method signature is used instead, here:

https://github.com/WeTransfer/prefixed_cache_store/commit/2c066389ecf39866f9c9db3da73fd90844d11152