### PR TITLE
use normalize_key instead of deprecated namespaced_key

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -156,7 +156,7 @@ module ActiveSupport
       def increment(key, amount = 1, options = {})
         options = merged_options(options)
         instrument(:increment, key, :amount => amount) do
-          with{|c| c.incrby namespaced_key(key, options), amount}
+          with{|c| c.incrby normalize_key(key, options), amount}
         end
       end
 
@@ -184,13 +184,13 @@ module ActiveSupport
       def decrement(key, amount = 1, options = {})
         options = merged_options(options)
         instrument(:decrement, key, :amount => amount) do
-          with{|c| c.decrby namespaced_key(key, options), amount}
+          with{|c| c.decrby normalize_key(key, options), amount}
         end
       end
 
       def expire(key, ttl)
         options = merged_options(nil)
-        with { |c| c.expire namespaced_key(key, options), ttl }
+        with { |c| c.expire normalize_key(key, options), ttl }
       end
 
       # Clear all the data from the store.

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -317,7 +317,7 @@ describe ActiveSupport::Cache::RedisStore do
 
   it "fetches data with expiration time" do
     with_store_management do |store|
-      store.fetch("rabbit", :force => true) # force cache miss
+      store.fetch("rabbit", :force => true) { @white_rabbit } # force cache miss
       store.fetch("rabbit", :force => true, :expires_in => 1.second) { @white_rabbit }
       store.fetch("rabbit").must_equal(@white_rabbit)
       sleep 2


### PR DESCRIPTION
This was already started in previous pulls.
`RedisStore#normalize_key` is already defined conditionally for backwards compatibility, so it's safe to simply replace all the occurrences of `namespaced_key` with `normalize_key` call 
