### PR TITLE
Support empty array in read_multi and fetch_multi

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -92,6 +92,7 @@ module ActiveSupport
       #   cache.read_multi "rabbit", "white-rabbit"
       #   cache.read_multi "rabbit", "white-rabbit", :raw => true
       def read_multi(*names)
+        return {} if names == []
         options = names.extract_options!
         keys = names.map{|name| normalize_key(name, options)}
         values = with { |c| c.mget(*keys) }
@@ -106,6 +107,7 @@ module ActiveSupport
       end
 
       def fetch_multi(*names)
+        return {} if names == []
         results = read_multi(*names)
         options = names.extract_options!
         fetched = {}

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -355,6 +355,11 @@ describe ActiveSupport::Cache::RedisStore do
     result['irish whisky'].must_equal("Jameson")
   end
 
+  it "read_multi return an empty {} when given an empty array" do
+    result = @store.read_multi(*[])
+    result.must_equal({})
+  end
+
   describe "fetch_multi" do
     it "reads existing keys and fills in anything missing" do
       @store.write "bourbon", "makers"
@@ -380,6 +385,11 @@ describe ActiveSupport::Cache::RedisStore do
       result.must_equal({ "bourbon" => "makers", "rye" => "rye-was-missing" })
       @store.read("rye").must_equal("rye-was-missing")
       @store.read("inner-rye").must_equal("rye-was-missing")
+    end
+
+    it "return an empty {} when given an empty array" do
+      result = @store.fetch_multi(*[]) { 1 }
+      result.must_equal({})
     end
   end
 

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -317,7 +317,7 @@ describe ActiveSupport::Cache::RedisStore do
 
   it "fetches data with expiration time" do
     with_store_management do |store|
-      store.fetch("rabbit", :force => true) # force cache miss
+      store.fetch("rabbit", :force => true) {} # force cache miss
       store.fetch("rabbit", :force => true, :expires_in => 1.second) { @white_rabbit }
       store.fetch("rabbit").must_equal(@white_rabbit)
       sleep 2


### PR DESCRIPTION
When switching from a memcached store to a redis store, we noticed a difference in behavior when passing an empty array into read_multi or fetch_multi.

With memcached (dalli gem):
```ruby
> Rails.cache.read_multi([])
=> {}
```

With redis (redis-rails gem):
```ruby
> Rails.cache.read_multi([])
NoMethodError: undefined method `map!' for nil:NilClass
```

This PR adds the same behavior to redis-activesupport and includes tests.

PS: I have [another branch](https://github.com/andruby/redis-activesupport/tree/empty-fetch-multi-4.1.6) that adds this on top of v4.1.5.