### PR TITLE
remove unnecessary codes

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -98,9 +98,6 @@ module ActiveSupport
         values = with { |c| c.mget(*keys) }
         values.map! { |v| v.is_a?(ActiveSupport::Cache::Entry) ? v.value : v }
 
-        # Remove the options hash before mapping keys to values
-        names.extract_options!
-
         result = Hash[names.zip(values)]
         result.reject!{ |k,v| v.nil? }
         result
@@ -110,7 +107,6 @@ module ActiveSupport
         return {} if names == []
         results = read_multi(*names)
         options = names.extract_options!
-        fetched = {}
         need_writes = {}
 
         fetched = names.inject({}) do |memo, (name, _)|


### PR DESCRIPTION
- `names.extract_options!` are called twice
- `fetched` get reassigned by `names.inject({})`