### PR TITLE
Dup redis connection addresses to avoid wrong lazy initialisation

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -35,6 +35,7 @@ module ActiveSupport
       #     # => supply an existing connection pool (e.g. for use with redis-sentinel or redis-failover)
       def initialize(*addresses)
         @options = addresses.dup.extract_options!
+        addresses = addresses.map(&:dup)
 
         @data = if @options[:pool]
                   raise "pool must be an instance of ConnectionPool" unless @options[:pool].is_a?(ConnectionPool)

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler',  '~> 1.3'
   s.add_development_dependency 'mocha',    '~> 0.14.0'
   s.add_development_dependency 'minitest', '>= 4.2', '< 6'
-  s.add_development_dependency 'connection_pool',     '~> 1.2.0'
+  s.add_development_dependency 'connection_pool', '~> 2.2.0'
   s.add_development_dependency 'redis-store-testing'
 end
 

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -56,6 +56,20 @@ describe ActiveSupport::Cache::RedisStore do
     redis.exists("rabbit").must_equal(true)
   end
 
+  it "connects using the passed hash of options" do
+    address = { host: '127.0.0.1', port: '6380', db: '1' }.merge(pool_size: 5, pool_timeout: 10)
+    store = ActiveSupport::Cache::RedisStore.new(address)
+    redis = Redis.new(url: "redis://127.0.0.1:6380/1")
+    redis.flushall
+    address[:db] = '0' # Should not use this db
+
+    store.data.class.must_equal(::ConnectionPool)
+
+    store.write("rabbit", 0)
+
+    redis.exists("rabbit").must_equal(true)
+  end
+
   it "raises an error if :pool isn't a pool" do
     assert_raises(RuntimeError, 'pool must be an instance of ConnectionPool') do
       ActiveSupport::Cache::RedisStore.new(pool: 'poolio')


### PR DESCRIPTION
From connection_pool >= 2.0.0 connections are created as needed and retained 
and the pool is shut down

https://github.com/mperham/connection_pool/blob/master/Changes.md#200

So we just need to dup each element of the address list, remember dup 

```ruby
    # Produces a shallow copy of <i>obj</i>---the instance variables of
    # <i>obj</i> are copied, but not the objects they reference.
    # <code>dup</code> copies the tainted state of <i>obj</i>.
    def dup()
    end
```

Example about what we map the dup

```ruby
irb(main):014:0> arr = [{a: 1}, {a: 2}]
=> [{:a=>1}, {:a=>2}]
irb(main):015:0> arr_2 = arr.dup
=> [{:a=>1}, {:a=>2}]
irb(main):016:0> arr_2[0][:a] = 4
=> 4
irb(main):017:0> arr[0]
=> {:a=>4}
```