### PR TITLE
Add support for race_condition_ttl on fetch

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -58,6 +58,9 @@ module ActiveSupport
         options = merged_options(options)
         instrument(:write, name, options) do |payload|
           entry = options[:raw].present? ? value : Entry.new(value, options)
+          if options[:expires_in].present? && options[:race_condition_ttl].present? && options[:raw].blank?
+            options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
+          end
           write_entry(normalize_key(name, options), entry, options)
         end
       end
@@ -296,4 +299,3 @@ module ActiveSupport
     end
   end
 end
-


### PR DESCRIPTION
http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html

> Setting :race_condition_ttl is very useful in situations where a cache entry is used very frequently and is under heavy load. If a cache expires and due to heavy load several different processes will try to read data natively and then they all will try to write to cache. To avoid that case the first process to find an expired cache entry will bump the cache expiration time by the value set in :race_condition_ttl. Yes, this process is extending the time for a stale value by another few seconds. Because of extended life of the previous cache, other processes will continue to use slightly stale data for a just a bit longer. In the meantime that first process will go ahead and will write into cache the new value. After that all the processes will start getting the new value. The key is to keep :race_condition_ttl small.

