### PR TITLE
Release v5.0.2

### DIFF
--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'redis-activesupport'
-  s.version     = '5.0.1'
+  s.version     = '5.0.2'
   s.authors     = ['Luca Guidi', 'Ryan Bigg']
   s.email       = ['me@lucaguidi.com', 'me@ryanbigg.com']
   s.homepage    = 'http://redis-store.org/redis-activesupport'


### PR DESCRIPTION
Cut a new gem release for v5.0.2. that uses the current v1.3.0 redis-store. 