### PR TITLE
Fix jbuilder_cache_multi compatibility

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -126,7 +126,7 @@ module ActiveSupport
         options = names.extract_options!
         need_writes = {}
 
-        fetched = names.inject({}) do |memo, (name, _)|
+        fetched = names.inject({}) do |memo, name|
           memo[name] = results.fetch(name) do
             value = yield name
             need_writes[name] = value

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -476,6 +476,22 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  describe "fetch_multi nested keys" do
+    it "reads existing keys and fills in anything missing" do
+      @store.write ["bourbon", "bourbon-extended"], "makers"
+
+      bourbon_key = ["bourbon", "bourbon-extended"]
+      rye_key = ["rye", "rye-extended"]
+
+      result = @store.fetch_multi(bourbon_key, rye_key) do |key|
+        "#{key}-was-missing"
+      end
+
+      result.must_equal({ bourbon_key => "makers", rye_key => "#{rye_key}-was-missing" })
+      @store.read(rye_key).must_equal("#{rye_key}-was-missing")
+    end
+  end
+
   describe "notifications" do
     it "notifies on #fetch" do
       with_notifications do


### PR DESCRIPTION
Hi guys. While moving from memcache to Redis, we have faced with jbuilder_cache_multi gem compatibility issue, which was described in #65.

So this PR fixes this problem by removing destructing block argument. The tests are green and I also checked some cases by myself, but my question is why we need this destructing there.

Please take a look guys. 