### PR TITLE
Support regular expressions in delete_matched

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -273,7 +273,6 @@ module ActiveSupport
           !!@options[:raise_errors]
         end
 
-
         # Add the namespace defined in the options to a pattern designed to match keys.
         #
         # This implementation is __different__ than ActiveSupport:
@@ -281,8 +280,10 @@ module ActiveSupport
         # only for strings with wildcards.
         def key_matcher(pattern, options)
           prefix = options[:namespace].is_a?(Proc) ? options[:namespace].call : options[:namespace]
+
+          pattern = pattern.inspect[1..-2] if pattern.is_a? Regexp
+
           if prefix
-            raise "Regexps aren't supported, please use string with wildcards." if pattern.is_a?(Regexp)
             "#{prefix}:#{pattern}"
           else
             pattern

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -176,7 +176,7 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
-  if RUBY_VERSION.match /1\.9/
+  if RUBY_VERSION.match(/1\.9/)
     it "reads raw data" do
       with_store_management do |store|
         result = store.read("rabbit", :raw => true)
@@ -221,6 +221,18 @@ describe ActiveSupport::Cache::RedisStore do
       store.write "rabbit2", @white_rabbit
       store.write "rub-a-dub", "Flora de Cana"
       store.delete_matched "rabb*"
+      store.read("rabbit").must_be_nil
+      store.read("rabbit2").must_be_nil
+      store.exist?("rub-a-dub").must_equal(true)
+    end
+  end
+
+  it 'deletes matched data with a regexp' do
+    with_store_management do |store|
+      store.write "rabbit2", @white_rabbit
+      store.write "rub-a-dub", "Flora de Cana"
+      store.delete_matched(/rabb*/)
+
       store.read("rabbit").must_be_nil
       store.read("rabbit2").must_be_nil
       store.exist?("rub-a-dub").must_equal(true)


### PR DESCRIPTION
Rails uses the type of the argument passed into `expire_fragment` to
determine whether it should be sent to
`ActiveSupport::Cache::Store#delete_matched` or
`ActiveSupport::Cache::Store#delete`. Regular expressions are passed
into `delete_matched`, so remove the error causing this to be impossible
in `RedisStore`, and ensure the regex is being stripped of non-essential
data before it's sent to Redis.

Note that there are no guarantees any of these regex's will work when
they get to Redis, we're just allowing Rails to use the correct method
here.

Fixes #56