### PR TITLE
Extract options from names before checking its size

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -109,8 +109,9 @@ module ActiveSupport
       #   cache.read_multi "rabbit", "white-rabbit"
       #   cache.read_multi "rabbit", "white-rabbit", :raw => true
       def read_multi(*names)
-        return {} if names == []
         options = names.extract_options!
+        return {} if names == []
+
         keys = names.map{|name| normalize_key(name, options)}
         values = with { |c| c.mget(*keys) }
         values.map! { |v| v.is_a?(ActiveSupport::Cache::Entry) ? v.value : v }
@@ -121,9 +122,10 @@ module ActiveSupport
       end
 
       def fetch_multi(*names)
-        return {} if names == []
-        results = read_multi(*names)
         options = names.extract_options!
+        return {} if names == []
+
+        results = read_multi(*names, options)
         need_writes = {}
 
         fetched = names.inject({}) do |memo, name|

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -415,6 +415,11 @@ describe ActiveSupport::Cache::RedisStore do
     result.must_equal({})
   end
 
+  it "read_multi return an empty {} when given an empty array with option" do
+    result = @store.read_multi(*[], option: true)
+    result.must_equal({})
+  end
+
   describe "fetch_multi" do
     it "reads existing keys and fills in anything missing" do
       @store.write "bourbon", "makers"
@@ -444,6 +449,11 @@ describe ActiveSupport::Cache::RedisStore do
 
     it "return an empty {} when given an empty array" do
       result = @store.fetch_multi(*[]) { 1 }
+      result.must_equal({})
+    end
+
+    it "return an empty {} when given an empty array with option" do
+      result = @store.read_multi(*[], option: true)
       result.must_equal({})
     end
   end


### PR DESCRIPTION
Hi guys. While integrating `redis-activesupport` with `jbuilder_cache_multi` gem I have found an issue, which happens when we pass empty array with some option to `#fetch_multi` or `#read_multi`. 

Example:
```ruby
RedisStore.fetch_multi(*[], option: 'value')
```
The code above raises the error [here:](https://github.com/redis-store/redis-activesupport/blob/master/lib/active_support/cache/redis_store.rb#L116)
```ruby
NoMethodError: undefined method `map!' for nil:NilClass 
```

It happens because we extract the options after checking the array.

Please take a look guys.