### PR TITLE
Fix :raw option for read_multi

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -100,7 +100,10 @@ module ActiveSupport
         return {} if names == []
 
         keys = names.map{|name| normalize_key(name, options)}
-        values = with { |c| c.mget(*keys) }
+        args = [keys, options]
+        args.flatten!
+
+        values = with { |c| c.mget(*args) }
         values.map! { |v| v.is_a?(ActiveSupport::Cache::Entry) ? v.value : v }
 
         result = Hash[names.zip(values)]

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -432,6 +432,14 @@ describe ActiveSupport::Cache::RedisStore do
     result.must_equal({})
   end
 
+  it "read_multi returns values with raw option" do
+    @store.write "raw-value-a", "A", raw: true
+    @store.write "raw-value-b", "B", raw: true
+
+    result = @store.read_multi("raw-value-a", "raw-value-b", :raw => true)
+    result.must_equal({ "raw-value-a" => "A", "raw-value-b" => "B" })
+  end
+
   describe "fetch_multi" do
     it "reads existing keys and fills in anything missing" do
       @store.write "bourbon", "makers"


### PR DESCRIPTION
This commit fixes the :raw option for read_multi. It also adds a small test case for this feature.