### PR TITLE
fix regression: redis_store.rb:38:in `dup': can't dup NilClass (TypeError)

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -35,7 +35,7 @@ module ActiveSupport
       #     # => supply an existing connection pool (e.g. for use with redis-sentinel or redis-failover)
       def initialize(*addresses)
         @options = addresses.dup.extract_options!
-        addresses = addresses.map(&:dup)
+        addresses = addresses.compact.map(&:dup)
 
         @data = if @options[:pool]
                   raise "pool must be an instance of ConnectionPool" unless @options[:pool].is_a?(ConnectionPool)

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -91,6 +91,11 @@ describe ActiveSupport::Cache::RedisStore do
     underlying_store.must_be_instance_of(::Redis::Store)
   end
 
+  it "creates a normal store when given nil" do
+    underlying_store = instantiate_store nil
+    underlying_store.must_be_instance_of(::Redis::Store)
+  end
+
   it "creates a normal store when given options only" do
     underlying_store = instantiate_store(:expires_in => 1.second)
     underlying_store.must_be_instance_of(::Redis::Store)


### PR DESCRIPTION
prior to ruby 2.4.0, nil are not duppable (see: https://bugs.ruby-lang.org/issues/12979)

this is to allow setting up redis_store in rails via ENV, e.g. `config.cache_store = :redis_store, ENV['CACHE_URL']`, which use to be working prior to cb481440ca44cf8d5f5c22c3a9ad56fb475f7ab0