### PR TITLE
Don't attempt to dup nil addresses

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -35,7 +35,7 @@ module ActiveSupport
       #     # => supply an existing connection pool (e.g. for use with redis-sentinel or redis-failover)
       def initialize(*addresses)
         @options = addresses.dup.extract_options!
-        addresses = addresses.map(&:dup)
+        addresses = addresses.compact.map(&:dup)
 
         @data = if @options[:pool]
                   raise "pool must be an instance of ConnectionPool" unless @options[:pool].is_a?(ConnectionPool)

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -70,6 +70,12 @@ describe ActiveSupport::Cache::RedisStore do
     redis.exists("rabbit").must_equal(true)
   end
 
+  it "does not raise an error if address is nil" do
+    assert_nothing_raised do
+      ActiveSupport::Cache::RedisStore.new(nil)
+    end
+  end
+
   it "raises an error if :pool isn't a pool" do
     assert_raises(RuntimeError, 'pool must be an instance of ConnectionPool') do
       ActiveSupport::Cache::RedisStore.new(pool: 'poolio')


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/redis-store/redis-activesupport/compare/v5.0.1...v5.0.3#diff-e3733da5a785a70938524842f66eedb8R38

If a `nil` address is passed into `ActiveSupport::Cache::RedisStore`, `addresses.map(&:dup)` will throw `TypeError: can't dup NilClass`.

This patch compacts the `addresses` array before the `map` call to prevent the exception and keep backwards compatibility.