### PR TITLE
Fix error rescue

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -8,7 +8,8 @@ module ActiveSupport
       ERRORS_TO_RESCUE = [
         Errno::ECONNREFUSED,
         Errno::EHOSTUNREACH,
-        Redis::CannotConnectError
+        Redis::CannotConnectError,
+        Redis::ConnectionError
       ].freeze
 
       attr_reader :data

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -652,6 +652,20 @@ describe ActiveSupport::Cache::RedisStore do
       end
     end
 
+    it "raises on read_multi when redis is unavailable" do
+      assert_raises(Redis::CannotConnectError) do
+        @raise_error_store.read_multi("rabbit", "white-rabbit")
+      end
+    end
+
+    it "raises on fetch_multi when redis is unavailable" do
+      assert_raises(Redis::CannotConnectError) do
+        @raise_error_store.fetch_multi("rabbit", "white-rabbit") do |key|
+          key.upcase
+        end
+      end
+    end
+
     it "raises on writes when redis is unavailable" do
       assert_raises(Redis::CannotConnectError) do
         @raise_error_store.write "rabbit", @white_rabbit, :expires_in => 1.second
@@ -677,8 +691,21 @@ describe ActiveSupport::Cache::RedisStore do
       @raise_error_store.stubs(:with).raises(Redis::CannotConnectError)
     end
 
-    it "is nil when redis is unavailable" do
+    it "returns nil from read when redis is unavailable" do
       @raise_error_store.read("rabbit").must_be_nil
+    end
+
+    it "returns empty hash from read_multi when redis is unavailable" do
+      @raise_error_store.read_multi("rabbit", "white-rabbit").must_equal({})
+    end
+
+    it "returns result hash from fetch_multi when redis is unavailable" do
+      @raise_error_store.fetch_multi("rabbit", "white-rabbit") do |key|
+        key.upcase
+      end.must_equal({
+        "rabbit" => "RABBIT",
+        "white-rabbit" => "WHITE-RABBIT",
+      })
     end
 
     it "returns false when redis is unavailable" do


### PR DESCRIPTION
There are 3 changes in this PR:

### 1. Rescue connection related errors in `read_multi` & `fetch_multi`
I got error report when Redis is down where I am using 
https://github.com/n8/multi_fetch_fragments
which internally use `read_multi`
So I make it and the alike `fetch_multi` rescue same set of errors too (and re-raise if option set)

### 2. Extract list of error classes into a constant
Just a simple refactor

### 3. Add `Redis::ConnectionError` into list of error to be rescue
When I got error reports when redis server is down, 
we got `Redis::ConnectionError` instead of `Redis:: CannotConnectError`.
`Redis:: CannotConnectError` is only used in `establish_connection`.
But if connection is established and the Redis server is down (reset?), 
`Redis::ConnectionError` is raised in [`Redis::Client#io`](https://github.com/redis/redis-rb/blob/v4.0.0/lib/redis/client.rb#L247) which is used by `#read` and `#write`

