### PR TITLE
Support recyclable cache keys

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -65,10 +65,10 @@ module ActiveSupport
       def write(name, value, options = nil)
         options = merged_options(options)
         instrument(:write, name, options) do |payload|
-          entry = options[:raw].present? ? value : Entry.new(value, options)
           if options[:expires_in].present? && options[:race_condition_ttl].present? && options[:raw].blank?
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
+          entry = options[:raw].present? ? value : Entry.new(value, options)
           write_entry(normalize_key(name, options), entry, options)
         end
       end
@@ -300,7 +300,6 @@ module ActiveSupport
         end
 
       private
-
         if ActiveSupport::VERSION::MAJOR < 5
           def normalize_key(*args)
             namespaced_key(*args)

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -370,7 +370,7 @@ describe ActiveSupport::Cache::RedisStore do
 
   describe "race_condition_ttl on fetch" do
     it "persist entry for longer than given ttl" do
-      options = { force: true, expires_in: 1.second, race_condition_ttl: 2.seconds }
+      options = { force: true, expires_in: 1.second, race_condition_ttl: 2.seconds, version: Time.now.to_i }
       @store.fetch("rabbit", options) { @rabbit }
       sleep 1.1
       @store.delete("rabbit").must_equal(1)
@@ -378,12 +378,12 @@ describe ActiveSupport::Cache::RedisStore do
 
     it "limits stampede time to read-write duration" do
       first_rabbit = second_rabbit = nil
-      options = { force: true, expires_in: 1.second, race_condition_ttl: 2.seconds }
+      options = { force: true, expires_in: 1.second, race_condition_ttl: 2.seconds, version: Time.now.to_i }
       @store.fetch("rabbit", options) { @rabbit }
       sleep 1
 
       th1 = Thread.new do
-        first_rabbit = @store.fetch("rabbit", race_condition_ttl: 2) do
+        first_rabbit = @store.fetch("rabbit", options) do
           sleep 1
           @white_rabbit
         end


### PR DESCRIPTION
ActiveSupport 5.2.0 introduces the concept of [recyclable cache
keys](https://github.com/rails/rails/pull/29092), which prevents a bunch of unnecessary keys being created and then having to be evicted. This should reduce the memory overhead of keeping a Redis or Memcache server up in order to support a cache. However, this caused issues for us because of an unneccessary override of `#write`. I can't really see much of a difference between our implementation and the one [baked into AS::Cache::Store](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache.rb#L438-L448), other than this `:race_condition_ttl` code which seems unnecessary since `Cache::Store` supports it under the hood.

This should fix issues that people are having with rails 5.2.0.rc1 and redis-activesupport.