### PR TITLE
Add option to pass Redis client to RedisStore.

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -20,6 +20,9 @@ module ActiveSupport
       #   RedisStore.new
       #     # => host: localhost,   port: 6379,  db: 0
       #
+      #   RedisStore.new client: Redis.new(url: "redis://127.0.0.1:6380/1")
+      #     # => host: localhost,   port: 6379,  db: 0
+      #
       #   RedisStore.new "example.com"
       #     # => host: example.com, port: 6379,  db: 0
       #
@@ -55,6 +58,8 @@ module ActiveSupport
                   pool_options[:timeout] = options[:pool_timeout] if options[:pool_timeout]
                   @pooled = true
                   ::ConnectionPool.new(pool_options) { ::Redis::Store::Factory.create(*addresses) }
+                elsif @options[:client]
+                  @options[:client]
                 else
                   ::Redis::Store::Factory.create(*addresses)
                 end

--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -26,6 +26,13 @@ describe ActiveSupport::Cache::RedisStore do
     end
   end
 
+  it "uses redis client passed as an option" do
+    redis = Redis.new(url: "redis://127.0.0.1:6380/1")
+    store = ActiveSupport::Cache::RedisStore.new(client: redis)
+
+    store.data.must_equal(redis)
+  end
+
   it "connects using an hash of options" do
     address = { host: '127.0.0.1', port: '6380', db: '1' }
     store = ActiveSupport::Cache::RedisStore.new(address.merge(pool_size: 5, pool_timeout: 10))


### PR DESCRIPTION
👋 Hello,

This PR adds an extra option to pass Redis client to RedisStore, it gives a nice option to construct Redis connection outside of the store. In my case I want decide where to read config for Redis based on environment: 
 - In development and test, I want to read configuration from yml file
 - In staging and production, I want to use Consul to discover where Redis cluster lives

I already have a class that is responsible for discovering Redis cluster config per environment, and I won't like to couple that with RedisStore.