### PR TITLE
Rescue Redis::TimeoutError which is raised when Redis server is shutting down

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -8,8 +8,9 @@ module ActiveSupport
       ERRORS_TO_RESCUE = [
         Errno::ECONNREFUSED,
         Errno::EHOSTUNREACH,
-        Redis::CannotConnectError,
-        Redis::ConnectionError
+        # This is what rails' redis cache store rescues
+        # https://github.com/rails/rails/blob/5-2-stable/activesupport/lib/active_support/cache/redis_cache_store.rb#L447
+        Redis::BaseConnectionError
       ].freeze
 
       attr_reader :data


### PR DESCRIPTION
`Redis::TimeoutError` is raised inside
https://github.com/redis/redis-rb/blob/master/lib/redis/connection/ruby.rb

I got error report when I restart Redis Server every time
I think we should rescue it since it means server is not responding properly

Does rails one has this feature??