### PR TITLE
Keeping consistent with RedisCacheStore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,19 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+  exclude:
     - rvm: 2.0
-      gemfile: gemfiles/Gemfile.activesupport-5.x
+      gemfile: gemfiles/activesupport_50.gemfile
     - rvm: 2.1
-      gemfile: gemfiles/Gemfile.activesupport-5.x
+      gemfile: gemfiles/activesupport_50.gemfile
+    - rvm: 2.0
+      gemfile: gemfiles/activesupport_51.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/activesupport_51.gemfile
+    - rvm: 2.0
+      gemfile: gemfiles/activesupport_52.gemfile
+    - rvm: 2.1
+      gemfile: gemfiles/activesupport_52.gemfile
 notifications:
   webhooks: https://www.travisbuddy.com/
   on_success: never


### PR DESCRIPTION
https://github.com/redis-store/redis-activesupport/pull/106#issuecomment-386638047

Not exactly the same as `RedisCacheStore`
- This gem has `raise_errors?` which is still used in `failsafe`
- This PR has `failsafe(:fetch_multi_write)` which is not in `RedisCacheStore` 
  (how's that implemented in `RedisCacheStore` this anyway?)
