### PR TITLE
Removed rubyforge_project from gemspec. 

### DIFF
--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -13,8 +13,6 @@ Gem::Specification.new do |s|
   s.description = %q{Redis store for ActiveSupport}
   s.license     = 'MIT'
 
-  s.rubyforge_project = 'redis-activesupport'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Because rubyforge was EOL today.