### PR TITLE
Symbolize parameters to allow for Rails 5.2 compatability

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -83,7 +83,7 @@ module ActiveSupport
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
 
-          options.deep_symbolize_keys!
+          options = options.to_h.deep_symbolize_keys
 
           entry = options[:raw].present? ? value : Entry.new(value, options)
           write_entry(normalize_key(name, options), entry, options)

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -82,7 +82,7 @@ module ActiveSupport
           if options[:expires_in].present? && options[:race_condition_ttl].present? && options[:raw].blank?
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
-          entry = options[:raw].present? ? value : Entry.new(value, options.to_h.symbolize_keys)
+          entry = options[:raw].present? ? value : Entry.new(value, **options.to_h.symbolize_keys)
           write_entry(normalize_key(name, options), entry, options)
         end
       end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -83,17 +83,9 @@ module ActiveSupport
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
 
-          if options[:raw].present?
-            entry = value
-          else
-            entry = Entry.new(
-              value,
-              compress: options[:compress],
-              compress_threshold: options[:compress_threshold],
-              version: options[:version],
-              expires_in: options[:expires_in]
-            )
-          end
+          options.deep_symbolize_keys!
+
+          entry = options[:raw].present? ? value : Entry.new(value, options)
           write_entry(normalize_key(name, options), entry, options)
         end
       end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -82,7 +82,6 @@ module ActiveSupport
           if options[:expires_in].present? && options[:race_condition_ttl].present? && options[:raw].blank?
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
-
           entry = options[:raw].present? ? value : Entry.new(value, options.to_h.symbolize_keys)
           write_entry(normalize_key(name, options), entry, options)
         end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -83,9 +83,7 @@ module ActiveSupport
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
 
-          options = options.to_h.symbolize_keys
-
-          entry = options[:raw].present? ? value : Entry.new(value, options)
+          entry = options[:raw].present? ? value : Entry.new(value, options.to_h.symbolize_keys)
           write_entry(normalize_key(name, options), entry, options)
         end
       end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -82,7 +82,18 @@ module ActiveSupport
           if options[:expires_in].present? && options[:race_condition_ttl].present? && options[:raw].blank?
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
-          entry = options[:raw].present? ? value : Entry.new(value, options)
+
+          if options[:raw].present?
+            entry = value
+          else
+            entry = Entry.new(
+              value,
+              compress: options[:compress],
+              compress_threshold: options[:compress_threshold],
+              version: options[:version],
+              expires_in: options[:expires_in]
+            )
+          end
           write_entry(normalize_key(name, options), entry, options)
         end
       end

--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -83,7 +83,7 @@ module ActiveSupport
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
 
-          options = options.to_h.deep_symbolize_keys
+          options = options.to_h.symbolize_keys
 
           entry = options[:raw].present? ? value : Entry.new(value, options)
           write_entry(normalize_key(name, options), entry, options)

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency "redis-store",   '>= 1.3', '< 2'
-  s.add_runtime_dependency 'activesupport', '>= 3', '< 6'
+  s.add_runtime_dependency 'activesupport', '>= 3', '< 7'
 
   s.add_development_dependency 'rake',     '>= 12.3.3'
   s.add_development_dependency 'bundler'

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency "redis-store",   '>= 1.3', '< 2'
-  s.add_runtime_dependency 'activesupport', '>= 5.2', '< 6'
+  s.add_runtime_dependency 'activesupport', '>= 3', '< 6'
 
   s.add_development_dependency 'rake',     '>= 12.3.3'
   s.add_development_dependency 'bundler'

--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency "redis-store",   '>= 1.3', '< 2'
-  s.add_runtime_dependency 'activesupport', '>= 3', '< 7'
+  s.add_runtime_dependency 'activesupport', '>= 5.2', '< 6'
 
   s.add_development_dependency 'rake',     '>= 12.3.3'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
In Rails 5.2 the method parameters changed inside of `ActiveSupport::Cache::Entry` from 

`def initialize(value, options = {})`

to 

`def initialize(value, compress: true, compress_threshold: DEFAULT_COMPRESS_LIMIT, version: nil, expires_in: nil, **` as of 5.2.4.3.

Because the options are a ActiveSupport::HashWithIndifferentAccess and not a symbol hash, they won't properly be applied to the symbol parameters in 5.2, converting them to a symbol hash makes the proper change and allows the invocation to continue.
