### PR TITLE
Remove deprecation warning when used in ruby 2.7

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -82,7 +82,7 @@ module ActiveSupport
           if options[:expires_in].present? && options[:race_condition_ttl].present? && options[:raw].blank?
             options[:expires_in] = options[:expires_in].to_f + options[:race_condition_ttl].to_f
           end
-          entry = options[:raw].present? ? value : Entry.new(value, options)
+          entry = options[:raw].present? ? value : Entry.new(value, **options)
           write_entry(normalize_key(name, options), entry, options)
         end
       end


### PR DESCRIPTION
The "Using the last argument as keyword parameters is deprecated" appears if we use this gem in ruby 2.7 and this commit remove it.