### PR TITLE
Fix Ruby 3.0 keyword arguments issue

### DIFF
--- a/lib/active_support/cache/redis_store.rb
+++ b/lib/active_support/cache/redis_store.rb
@@ -302,7 +302,7 @@ module ActiveSupport
         #
         # It's really needed and use
         #
-        def delete_entry(key, options)
+        def delete_entry(key, **options)
           failsafe(:delete_entry, returning: false) do
             with { |c| c.del key }
           end


### PR DESCRIPTION
There is another issue with the keyword argument handling. With this small patch, the tests run successfully with Ruby 3.0 as well.