### PR TITLE
Bump `activesupport` support version to 7.X

### DIFF
--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency "redis-store",   '>= 1.3', '< 2'
-  s.add_runtime_dependency 'activesupport', '>= 3', '< 7'
+  s.add_runtime_dependency 'activesupport', '>= 3', '< 8'
 
   s.add_development_dependency 'rake',     '>= 12.3.3'
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
This change corresponds to the recently released `rails` version 7.X.

https://github.com/rails/rails/blob/7-0-stable/activesupport/CHANGELOG.md#rails-700-december-15-2021

```
In Gemfile:
  rails (= 7.0.0) was resolved to 7.0.0, which depends on
    activesupport (= 7.0.0)

  redis-activesupport was resolved to 5.2.1, which depends on
    activesupport (>= 3, < 7)
```

I referred to PR https://github.com/redis-store/redis-activesupport/pull/121.
Therefore, the version specification is specified so that all 7 series support it.

FYI
Similarly `redis-actionpack` I also changed `.
https://github.com/redis-store/redis-actionpack/pull/36