### PR TITLE
Use redis.exists? method instead of exists

### DIFF
--- a/test/active_support/cache/redis_store_test.rb
+++ b/test/active_support/cache/redis_store_test.rb
@@ -45,7 +45,7 @@ describe ActiveSupport::Cache::RedisStore do
 
     store.write("rabbit", 0)
 
-    redis.exists("rabbit").must_equal(true)
+    redis.exists?("rabbit").must_equal(true)
   end
 
   it "connects using an string of options" do
@@ -60,7 +60,7 @@ describe ActiveSupport::Cache::RedisStore do
 
     store.write("rabbit", 0)
 
-    redis.exists("rabbit").must_equal(true)
+    redis.exists?("rabbit").must_equal(true)
   end
 
   it "connects using the passed hash of options" do
@@ -74,7 +74,7 @@ describe ActiveSupport::Cache::RedisStore do
 
     store.write("rabbit", 0)
 
-    redis.exists("rabbit").must_equal(true)
+    redis.exists?("rabbit").must_equal(true)
   end
 
   it "raises an error if :pool isn't a pool" do
@@ -90,7 +90,7 @@ describe ActiveSupport::Cache::RedisStore do
 
     store.write("white-rabbit", 0)
 
-    redis.exists('cache-namespace:white-rabbit').must_equal(true)
+    redis.exists?('cache-namespace:white-rabbit').must_equal(true)
   end
 
   it "creates a normal store when given no addresses" do


### PR DESCRIPTION
According to
https://github.com/redis/redis-rb/blob/e3cf29dfb1d933bcd6670eb87a6246d54546cd80/lib/redis.rb#L17,
it is recommended to use the "exists?" method instead of the
"exists".

On Debian, we're seeing 4 related failures when using "exists".
Here's one:

  1) Failure:
ActiveSupport::Cache::RedisStore#test_0006_namespaces all operations [/<<PKGBUILDDIR>>/test/active_support/cache/redis_store_test.rb:93]:
Expected: true
  Actual: 1

These failures are solved by using "exists?".